### PR TITLE
Add ECDC and EAC, rework TMX parsing to support multilingual TMXes

### DIFF
--- a/mtdata/index/__init__.py
+++ b/mtdata/index/__init__.py
@@ -86,7 +86,7 @@ def get_entries(langs=None, names=None, not_names=None) -> List[Entry]:
 def load_all():
     from mtdata.index import (statmt, paracrawl, tilde, literature, joshua_indian, globalvoices,
                               unitednations, wikimatrix, other, neulab_tedtalks, elrc_share,
-                              ai4bharat)
+                              ai4bharat, eu)
     from mtdata.index.opus import opus_index, jw300, opus100
 
     counts = {}
@@ -105,6 +105,7 @@ def load_all():
         ('Neulab_TEDTalksv1', neulab_tedtalks.load_all),
         ('ELRC-SHARE', elrc_share.load_all),
         ('AI4Bharat', ai4bharat.load_all),
+        ('EU', eu.load_all)
     ]
     for name, loader in subsets:
         n = len(INDEX)

--- a/mtdata/index/eu.py
+++ b/mtdata/index/eu.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Corpora from the EU https://ec.europa.eu/jrc/en/language-technologies
+# Author: Kenneth Heafield [mtdata (at) kheafield (dot) com] 
+# Created: 5/23/21
+
+from mtdata.index import Index, Entry
+
+def load_all(index: Index):
+    # === ECDC ===
+    # https://ec.europa.eu/jrc/en/language-technologies/ecdc-translation-memory
+    cite="""@article{Steinberger2014,
+    title={An overview of the European Union's highly multilingual parallel corpora},
+    journal={Language Resources and Evaluation},
+    author={Steinberger, Ralf and Ebrahim, Mohamed and Poulis, Alexandros and Carrasco-Benitez, Manuel and Schlüter, Patrick and Przybyszewski, Marek and Gilbro, Signe},
+    year={2014},
+    doi={10.1007/s10579-014-9277-0},
+    url={https://ec.europa.eu/jrc/sites/jrcsh/files/2014_08_LRE-Journal_JRC-Linguistic-Resources_Manuscript.pdf},
+    pages={679--707},
+}"""
+    langs = ["en", "bg", "cs", "da", "de", "el", "es", "et", "fi", "fr", "ga", "hu", "is", "it", "lt", "lv", "mt", "nl", "no", "pl", "pt", "ro", "sk", "sl", "sv"]
+    for i, l1 in enumerate(langs):
+        for l2 in langs[i+1:]:
+            ent = Entry(langs=(l1, l2), url="http://optima.jrc.it/Resources/ECDC-TM/ECDC-TM.zip", name="ECDC", in_ext='tmx', cite=cite, in_paths=["ECDC-TM/ECDC.tmx"])
+            index.add_entry(ent)
+
+    # === EAC ===
+    # https://ec.europa.eu/jrc/en/language-technologies/eac-translation-memory
+    # This corpus has two 
+    langs = ["bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "hu", "is", "it", "lt", "lv", "mt", "nb", "nl", "pl", "pt", "ro", "sk", "sl", "sv", "tr"]
+    for i, l1 in enumerate(langs):
+        for l2 in langs[i+1:]:
+            ent = Entry(langs=(l1, l2), url="https://wt-public.emm4u.eu/Resources/EAC-TM/EAC-TM-all.zip", name="EAC_Forms", in_ext='tmx', cite=cite, in_paths=["EAC_FORMS.tmx"])
+            index.add_entry(ent)
+    langs = ["bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "hr", "hu", "is", "it", "lt", "lv", "mt", "nl", "no", "pl", "pt", "ro", "sk", "sl", "sv", "tr"]
+    for i, l1 in enumerate(langs):
+        for l2 in langs[i+1:]:
+            ent = Entry(langs=(l1, l2), url="https://wt-public.emm4u.eu/Resources/EAC-TM/EAC-TM-all.zip", name="EAC_Reference", in_ext='tmx', cite=cite, in_paths=["EAC_REFRENCE_DATA.tmx"])
+            index.add_entry(ent)
+
+    # Note: DGT-TM is already in via OPUS.

--- a/mtdata/index/other.py
+++ b/mtdata/index/other.py
@@ -113,3 +113,21 @@ def load_all(index: Index):
                     cite=cite, filename='NunavutHansard_iuen_v3.tgz',
                     in_paths=[f'{path_pref}.{l1}', f'{path_pref}.{l2}'])
         index.add_entry(ent)
+
+
+
+    # === ECDC ===
+    cite="""@article{Steinberger2014,
+    title={An overview of the European Union's highly multilingual parallel corpora},
+    journal={Language Resources and Evaluation},
+    author={Steinberger, Ralf and Ebrahim, Mohamed and Poulis, Alexandros and Carrasco-Benitez, Manuel and Schlüter, Patrick and Przybyszewski, Marek and Gilbro, Signe},
+    year={2014},
+    doi={10.1007/s10579-014-9277-0},
+    url={https://ec.europa.eu/jrc/sites/jrcsh/files/2014_08_LRE-Journal_JRC-Linguistic-Resources_Manuscript.pdf},
+    pages={679--707},
+}"""
+    langs = ["en", "bg", "cs", "da", "de", "el", "es", "et", "fi", "fr", "ga", "hu", "is", "it", "lt", "lv", "mt", "nl", "no", "pl", "pt", "ro", "sk", "sl", "sv"]
+    for i, l1 in enumerate(langs):
+        for l2 in langs[i+1:]:
+            ent = Entry(langs=(l1, l2), url="http://optima.jrc.it/Resources/ECDC-TM/ECDC-TM.zip", name="ECDC", in_ext='tmx', cite=cite, in_paths=["ECDC-TM/ECDC.tmx"])
+            index.add_entry(ent)

--- a/mtdata/index/other.py
+++ b/mtdata/index/other.py
@@ -113,21 +113,3 @@ def load_all(index: Index):
                     cite=cite, filename='NunavutHansard_iuen_v3.tgz',
                     in_paths=[f'{path_pref}.{l1}', f'{path_pref}.{l2}'])
         index.add_entry(ent)
-
-
-
-    # === ECDC ===
-    cite="""@article{Steinberger2014,
-    title={An overview of the European Union's highly multilingual parallel corpora},
-    journal={Language Resources and Evaluation},
-    author={Steinberger, Ralf and Ebrahim, Mohamed and Poulis, Alexandros and Carrasco-Benitez, Manuel and Schlüter, Patrick and Przybyszewski, Marek and Gilbro, Signe},
-    year={2014},
-    doi={10.1007/s10579-014-9277-0},
-    url={https://ec.europa.eu/jrc/sites/jrcsh/files/2014_08_LRE-Journal_JRC-Linguistic-Resources_Manuscript.pdf},
-    pages={679--707},
-}"""
-    langs = ["en", "bg", "cs", "da", "de", "el", "es", "et", "fi", "fr", "ga", "hu", "is", "it", "lt", "lv", "mt", "nl", "no", "pl", "pt", "ro", "sk", "sl", "sv"]
-    for i, l1 in enumerate(langs):
-        for l2 in langs[i+1:]:
-            ent = Entry(langs=(l1, l2), url="http://optima.jrc.it/Resources/ECDC-TM/ECDC-TM.zip", name="ECDC", in_ext='tmx', cite=cite, in_paths=["ECDC-TM/ECDC.tmx"])
-            index.add_entry(ent)


### PR DESCRIPTION
The ECDC TMX file has multiple languages as different segments.  This reworks the TMX parser to support that.  