### PR TITLE
Optimize dataset index loading using cache; 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ v0.2.10-dev - WIP
 - Fix line count mismatch in some XML formats [#45][p45] 
 - Parse BCP47 codes by removing everything after first hyphen [#48][p48] -- by [@kpu](https://github.com/kpu) 
 - Add Khresmoi datasets [#53][p53] -- by [@kpu](https://github.com/kpu)
+- Optimize index loading by using cache; 
+  - Added `-re | --reindex` CLI flag to force update index cache [#54][i54]  
+  - Removed `--cache` CLI argument. Use `export MTDATA=/path/to/cache-dir` instead (which was already supported)
 
 [i37]: https://github.com/thammegowda/mtdata/issues/37
 [i35]: https://github.com/thammegowda/mtdata/issues/35
@@ -35,6 +38,7 @@ v0.2.10-dev - WIP
 [p48]: https://github.com/thammegowda/mtdata/pull/48
 [p53]: https://github.com/thammegowda/mtdata/pull/53 
 [p43]: https://github.com/thammegowda/mtdata/pull/43 
+[i54]: https://github.com/thammegowda/mtdata/issues/54
 
 ----
 # v0.2.9 - 20210517

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Entry(..., cite=cite)
 
 When index is modified without incrementing version number, you will have to force refresh cache of index. The following command with `-ri` or `--reindex` flag helps reindex datasets. 
 
-`python -m mtdata -ri list ` or `python -m mtdata --reindex list ` to refresh cahce of index.  
+`python -m mtdata -ri list ` or `python -m mtdata --reindex list ` to refresh cache of index.  
 
 For adding a custom parser, or file handler look into [`parser.read_segs()`](mtdata/parser.py) 
 and [`cache`](mtdata/cache.py) for dealing with a new archive/file type that is not already supported.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ print(iso3_code('eNgLIsH', fail_error=True))  # case doesnt matter
 ```
 
 # How to extend, modify, or contribute:
-Please help grow the datasets by adding missing+new datasets to [`index`](mtdata/index/__init__.py) module.
+Please help grow the datasets by adding any missing and new datasets to [`index`](mtdata/index/__init__.py) module.
 Here is an example listing europarl-v9 corpus.
 Note: the language codes such as `de` `en` etc will be mapped to 3 letter ISO codes `deu` `eng` internally
 ```python
@@ -276,13 +276,26 @@ cite = index.ref_db.get_bibtex('author-etal')
 Entry(..., cite=cite)
 ```
 
+When index is modified without incrementing version number, you will have to force refresh cache of index. The following command with `-ri` or `--reindex` flag helps reindex datasets. 
+
+`python -m mtdata -ri list ` or `python -m mtdata --reindex list ` to refresh cahce of index.  
+
 For adding a custom parser, or file handler look into [`parser.read_segs()`](mtdata/parser.py) 
 and [`cache`](mtdata/cache.py) for dealing with a new archive/file type that is not already supported.
+
+## Change Cache Directory:
+
+The default cache directory is `$HOME/.mtdata`. To change it, set the following environment variable
+`export MTDATA=/path/to/new-cache-dir`
+
+
  
 ## Run tests
 Tests are located in [tests/](tests) directory. To run all the tests:
 
     python -m pytest
+
+
 
 ## Developers and Contributor:
 See - https://github.com/thammegowda/mtdata/graphs/contributors

--- a/mtdata/__init__.py
+++ b/mtdata/__init__.py
@@ -14,3 +14,4 @@ import os
 debug_mode = False
 log.basicConfig(level=log.INFO)
 cache_dir = Path(os.environ.get('MTDATA', '~/.mtdata')).expanduser()
+cached_index_file = cache_dir / f'mtdata.index.{__version__}.pkl'

--- a/mtdata/entry.py
+++ b/mtdata/entry.py
@@ -83,10 +83,9 @@ class Experiment:
             assert t
 
     @classmethod
-    def make(cls, langs: Tuple[str, str], train: List[str], tests: List[str]):
-        from mtdata.index import INDEX
-        train = [INDEX.get_entry(name, langs) for name in train]
-        tests = [INDEX.get_entry(name, langs) for name in tests]
+    def make(cls, index, langs: Tuple[str, str], train: List[str], tests: List[str]):
+        train = [index.get_entry(name, langs) for name in train]
+        tests = [index.get_entry(name, langs) for name in tests]
         return cls(langs, train=train, tests=tests)
 
 

--- a/mtdata/index/__init__.py
+++ b/mtdata/index/__init__.py
@@ -28,6 +28,7 @@ class Index:
         if not cls.obj:
             if not cached_index_file.exists():
                 log.info("Creating a fresh index object")
+                cached_index_file.parent.mkdir(exist_ok=True)
                 lock_file = cached_index_file.with_suffix("._lock")
                 with portalocker.Lock(lock_file, 'w', timeout=60) as fh:
                     # got lock, check cache is not created by parallel processes while we waited

--- a/mtdata/index/__init__.py
+++ b/mtdata/index/__init__.py
@@ -2,20 +2,85 @@
 #
 # Author: Thamme Gowda [tg (at) isi (dot) edu] 
 # Created: 4/8/20
-from mtdata import log
+from mtdata import log, cached_index_file, __version__
 from mtdata.entry import Entry, Paper
 from typing import List, Optional
 from pathlib import Path
+import pickle
+import portalocker
 from pybtex.database import parse_file as parse_bib_file
 
 REFS_FILE = Path(__file__).parent / 'refs.bib'
 
+
 class Index:
 
+    obj = None   # singleton object
+
     def __init__(self):
-        self.entries = {}  # uniq
-        self.papers = {}  # uniq
+        self.entries = {}  # unique
+        self.papers = {}  # unique
         self.ref_db = ReferenceDb()
+        self.version = __version__
+
+    @classmethod
+    def get_instance(cls):
+        if not cls.obj:
+            if not cached_index_file.exists():
+                log.info("Creating a fresh index object")
+                lock_file = cached_index_file.with_suffix("._lock")
+                with portalocker.Lock(lock_file, 'w', timeout=60) as fh:
+                    # got lock, check cache is not created by parallel processes while we waited
+                    if not cached_index_file.exists():
+                        obj = Index()
+                        log.info("Indexing all datasets...")
+                        obj.load_all()
+                        log.info(f"Caching my index file at {cached_index_file}")
+                        with open(cached_index_file, 'wb') as out:
+                            pickle.dump(obj, out)
+
+            assert cached_index_file.exists()
+            log.info(f"Loading index from cache {cached_index_file}")
+            with open(cached_index_file, 'rb') as inp:
+                obj = pickle.load(inp)
+
+            assert isinstance(obj, cls), f'{cached_index_file} isnt valid. please move or remove it'
+            cls.obj = obj
+        return cls.obj
+
+
+    def load_all(self):
+        from mtdata.index import (statmt, paracrawl, tilde, literature, joshua_indian,
+                                  unitednations, wikimatrix, other, neulab_tedtalks, elrc_share,
+                                  ai4bharat, eu)
+        from mtdata.index.opus import opus_index, jw300, opus100
+
+        counts = {}
+        subsets = [
+            ('Statmt.org', statmt.load),
+            ('Paracrawl', paracrawl.load),
+            ('Tilde', tilde.load),
+            ('JoshuaIndianCoprus', joshua_indian.load_all),
+            ('UnitedNations', unitednations.load_all),
+            ('OPUS', opus_index.load_all),
+            ('OPUS_JW300', jw300.load_all),
+            ('OPUS100', opus100.load_all),
+            ('WikiMatrix', wikimatrix.load_all),
+            ('Other', other.load_all),
+            ('Neulab_TEDTalksv1', neulab_tedtalks.load_all),
+            ('ELRC-SHARE', elrc_share.load_all),
+            ('AI4Bharat', ai4bharat.load_all),
+            ('EU', eu.load_all)
+        ]
+        for name, loader in subsets:
+            n = len(self)
+            loader(self)
+            counts[name] = len(self) - n
+        items = list(sorted(counts.items(), key=lambda x: x[1], reverse=True))
+        items += [('Total', len(self))]
+        counts = '  '.join([f'{n}:{c:,}' for n, c in items])
+        log.info(f"Index status: {counts}")
+        literature.load(self)
 
     @property
     def n_entries(self) -> int:
@@ -87,8 +152,6 @@ class ReferenceDb:
     def keys(self):
         return self.db.entries.keys()
 
-INDEX: Index = Index()
-
 
 def get_entries(langs=None, names=None, not_names=None) -> List[Entry]:
     """
@@ -112,41 +175,4 @@ def get_entries(langs=None, names=None, not_names=None) -> List[Entry]:
         select = [e for e in select if e.name not in not_names]
     return select
 
-
-def load_all():
-    from mtdata.index import (statmt, paracrawl, tilde, literature, joshua_indian,
-                              unitednations, wikimatrix, other, neulab_tedtalks, elrc_share,
-                              ai4bharat, eu)
-    from mtdata.index.opus import opus_index, jw300, opus100
-
-    counts = {}
-    subsets = [
-        ('Statmt.org', statmt.load),
-        ('Paracrawl', paracrawl.load),
-        ('Tilde', tilde.load),
-        ('JoshuaIndianCoprus', joshua_indian.load_all),
-        ('UnitedNations', unitednations.load_all),
-        ('OPUS', opus_index.load_all),
-        ('OPUS_JW300', jw300.load_all),
-        ('OPUS100', opus100.load_all),
-        ('WikiMatrix', wikimatrix.load_all),
-        ('Other', other.load_all),
-        ('Neulab_TEDTalksv1', neulab_tedtalks.load_all),
-        ('ELRC-SHARE', elrc_share.load_all),
-        ('AI4Bharat', ai4bharat.load_all),
-        ('EU', eu.load_all)
-    ]
-    for name, loader in subsets:
-        n = len(INDEX)
-        loader(INDEX)
-        counts[name] = len(INDEX) - n
-    items = list(sorted(counts.items(), key=lambda x:x[1], reverse=True))
-    items += [('Total', len(INDEX))]
-    counts = '  '.join([f'{n}:{c:,}' for n, c in items])
-    log.info(f"Index status: {counts}")
-    literature.load(INDEX)
-
-
-# eager load, as of now
-# TODO: lazy load and/or cache the index on disk
-load_all()
+INDEX: Index = Index.get_instance()

--- a/mtdata/index/literature.py
+++ b/mtdata/index/literature.py
@@ -15,7 +15,7 @@ def load(index: Index):
         url="https://papers.nips.cc/paper/7181-attention-is-all-you-need.pdf",
         cite=index.ref_db.get_bibtex('vaswani2017attention'),
         experiments=[
-            Experiment.make(
+            Experiment.make(index=index,
                 langs=('eng', 'deu'),
                 train=['wmt13_europarl_v7', 'wmt13_commoncrawl', 'wmt18_news_commentary_v13'],
                 tests=['newstest2013', 'newstest2014_deen'])


### PR DESCRIPTION
- `-ri | --reindex` CLI opt to  refresh the cache
- removed `--cache` as it was redundant to MTDATA env variable. It is not easy to reliably dynamically update all modules when a new cache dir is specified in CLI

Closes #54 