### PR TITLE
Fixed a bug in KECL JParaCrawl v3 extraction used in WMT22 en-ja translation task

### DIFF
--- a/mtdata/__init__.py
+++ b/mtdata/__init__.py
@@ -3,7 +3,7 @@
 # Author: Thamme Gowda [tg (at) isi (dot) edu] 
 # Created: 4/4/20
 
-__version__ = '0.3.5'
+__version__ = '0.3.6'
 __description__ = 'mtdata is a tool to download datasets for machine translation'
 __author__ = 'Thamme Gowda'
 

--- a/mtdata/index/paracrawl.py
+++ b/mtdata/index/paracrawl.py
@@ -78,8 +78,8 @@ def load(index: Index):
         cite=cite, ext='tsv.gz'))
 
     # Japanese-English paracrawl (5.1) used by WMT20 and WMT21
-    for version in ['2', '3']:
+    for version, cols in [('2', (2, 3)), ('3', (3, 4))]:
         ent = Entry(did=DatasetId(group='KECL', name=f'paracrawl', version=version, langs=('eng', 'jpn')),
-                    in_paths=['en-ja/en-ja.bicleaner05.txt'], in_ext='tsv', cols=(2, 3), cite='',
+                    in_paths=['en-ja/en-ja.bicleaner05.txt'], in_ext='tsv', cols=cols, cite='',
                     url=f'http://www.kecl.ntt.co.jp/icl/lirg/jparacrawl/release/{version}.0/bitext/en-ja.tar.gz')
         index.add_entry(ent)


### PR DESCRIPTION
Fixed a bug in the extraction of JParaCrawl v3 used in WMT22 en-ja translation task.
The minor version has been bumped to need to update the index cache.