### PR TITLE
chore: Add setuptools to dependencies for 3.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "enlighten==1.10.1",
     "portalocker==2.3.0",
     "pybtex==0.24.0",
+    "setuptools; python_version >= '3.12'",  # Needed until pybtex updates
     "ruamel.yaml >= 0.17.10"
 ]
 


### PR DESCRIPTION
Closes #172. Should probably open an issue to remove this once a newer pybtex is released.